### PR TITLE
	Added specs for stanza objects that refers to another file

### DIFF
--- a/grammars/splunk-conf.cson
+++ b/grammars/splunk-conf.cson
@@ -26,6 +26,22 @@ patterns: [
     name: "entity.name.function"
   }
   {
+    match: "(TRANSFORMS-.+?)=(.+)"
+    comment: "Regular expressions"
+    captures: {
+      1: { name: "entity.name.type" }
+      2: { name: "string" }
+    }
+  }
+  {
+    match: "(REPORT-.+?)=(.+)"
+    comment: "Regular expressions"
+    captures: {
+      1: { name: "support.function" }
+      2: { name: "string" }
+    }
+  }
+  {
     comment: "conf setting key"
     match: "^[\\w+\\.\\-\\:]+"
     name: "support.function"


### PR DESCRIPTION
Added specs for stanza objects that refers to another file. In particular, added specs for:
- TRANSFORMS: index time rule (props.conf) with reference in transforms.conf
- REPORT: search time rule (props.conf) with reference in transforms.conf

![image](https://cloud.githubusercontent.com/assets/2895329/16619129/1a8d5608-438d-11e6-80df-4fa055760d37.png)
